### PR TITLE
Movement is now case-insensitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "finding-ciri-cli-game",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -77,9 +77,10 @@ function startGame(isNextTurn){
     prompt.get({
         description : 'Please enter a movement option',
         type : 'string',
-        pattern : /^([NSEW]|[NS][EW])$/,
+        pattern : /^([NSEW]|[NS][EW])$/i,
         message : 'Please choose an appropriate movement option',
-        require : true
+        require : true,
+        before: val => val.toUpperCase()
     },function(err,result){
         console.log('You choose '+result.question+' ('+mapEngine.getFullDirection(result.question)+')');
         var nextTile = mapEngine.getObjectFromCurrentPosition(player.x,player.y,result.question);


### PR DESCRIPTION
User can now type lower or uppercase movement commands.

Such as (n => N) (ne => NE).

#2 